### PR TITLE
Fix `Logger` memory leak by making `TelemetryConfiguration` static

### DIFF
--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Configuration/AppInsightsConfiguration.cs
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Configuration/AppInsightsConfiguration.cs
@@ -3,5 +3,7 @@
     internal class AppInsightsConfiguration : IAppInsightsConfiguration
     {
         public string? ConnectionString { get; set; }
+
+        public string? TelemetryChannel { get; set; }
     }
 }

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Configuration/IAppInsightsConfiguration.cs
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Configuration/IAppInsightsConfiguration.cs
@@ -3,5 +3,13 @@
     public interface IAppInsightsConfiguration
     {
         string? ConnectionString { get; }
+
+        /// <summary>
+        /// The `TelemetryChannel` to use, either "InMemoryChannel" or "ServerTelemetryChannel".
+        /// </summary>
+        /// <remarks>
+        /// Microsoft recommends using "ServerTelemetryChannel" in all production scenarios.
+        /// </remarks>
+        string? TelemetryChannel { get; }
     }
 }

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights.csproj
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights.csproj
@@ -34,6 +34,7 @@
     <ItemGroup>
       <PackageReference Include="DontPanicLabs.Ifx.Configuration.Local" Version="1.0.0" />
       <PackageReference Include="DontPanicLabs.Ifx.Telemetry.Logger.Contracts" Version="1.0.0" />
+      <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.23.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" />
     </ItemGroup>
 

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Exceptions/InvalidTelemetryChannelException.cs
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Exceptions/InvalidTelemetryChannelException.cs
@@ -1,0 +1,23 @@
+namespace DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights.Exceptions;
+
+public class InvalidTelemetryChannelException : ArgumentException
+{
+    private const string InvalidTelemetryChannel = "A `TelemetryChannel` was provided, but its value '{0}' was invalid.";
+
+    InvalidTelemetryChannelException(string message) : base(message)
+    {
+    }
+
+    public static InvalidTelemetryChannelException Create(string? channel)
+    {
+        return new InvalidTelemetryChannelException(string.Format(InvalidTelemetryChannel, channel));
+    }
+
+    public static void ThrowIfChannelInvalid(string? channel)
+    {
+        if (!string.IsNullOrEmpty(channel) && channel != "InMemoryChannel" && channel != "ServerTelemetryChannel")
+        {
+            throw Create(channel);
+        }
+    }
+}

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Logger.cs
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Logger.cs
@@ -10,18 +10,22 @@ namespace DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights
     public sealed class Logger : Contracts.ILogger
     {
         private readonly TelemetryClient _TelemetryClient;
+        private static readonly Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration TelemetryConfig;
 
-        public Logger()
+        static Logger()
         {
             IConfiguration configuration = new Config();
             IAppInsightsConfiguration appInsightsConfig = configuration.GetAppInsightsConfiguration();
 
             EmptyConnectionStringException.ThrowIfEmpty(appInsightsConfig.ConnectionString!);
 
-            _TelemetryClient = new TelemetryClient(new Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
-            {
-                ConnectionString = appInsightsConfig.ConnectionString
-            });
+            TelemetryConfig = Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.CreateDefault();
+            TelemetryConfig.ConnectionString = appInsightsConfig.ConnectionString;
+        }
+
+        public Logger()
+        {
+            _TelemetryClient = new TelemetryClient(TelemetryConfig);
         }
 
         void Contracts.ILogger.Flush()

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Logger.cs
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Logger.cs
@@ -2,14 +2,16 @@ using DontPanicLabs.Ifx.Configuration.Local;
 using DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights.Configuration;
 using DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights.Exceptions;
 using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.Extensions.Configuration;
 
 namespace DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights
 {
     public sealed class Logger : Contracts.ILogger
     {
         private readonly TelemetryClient _TelemetryClient;
+
+        private static ITelemetryChannel? _telemetryChannel;
 
         /// <remarks>
         /// `TelemetryConfiguration` is static so that it can be reused across instances of the logger; failure to
@@ -20,15 +22,9 @@ namespace DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights
 
         public Logger()
         {
-            IConfiguration configuration = new Config();
-            IAppInsightsConfiguration appInsightsConfig = configuration.GetAppInsightsConfiguration();
+            IAppInsightsConfiguration appInsightsConfig = new Config().GetAppInsightsConfiguration();
 
-            EmptyConnectionStringException.ThrowIfEmpty(appInsightsConfig.ConnectionString!);
-
-            if (string.IsNullOrEmpty(TelemetryConfig.ConnectionString))
-            {
-                TelemetryConfig.ConnectionString = appInsightsConfig.ConnectionString;
-            }
+            ConfigureTelemetry(appInsightsConfig);
 
             _TelemetryClient = new TelemetryClient(TelemetryConfig);
         }
@@ -68,5 +64,24 @@ namespace DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights
             _TelemetryClient.TrackException(ex, properties);
         }
 
+        private static void ConfigureTelemetry(IAppInsightsConfiguration appInsightsConfig)
+        {
+            EmptyConnectionStringException.ThrowIfEmpty(appInsightsConfig.ConnectionString!);
+            TelemetryConfig.ConnectionString ??= appInsightsConfig.ConnectionString;
+
+            InvalidTelemetryChannelException.ThrowIfChannelInvalid(appInsightsConfig.TelemetryChannel);
+            if (_telemetryChannel == null)
+            {
+                _telemetryChannel = appInsightsConfig.TelemetryChannel switch
+                {
+                    "ServerTelemetryChannel" =>
+                        new Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel(),
+                    var channel when string.IsNullOrEmpty(channel) || channel == "InMemoryChannel" =>
+                        new InMemoryChannel(),
+                    _ => throw InvalidTelemetryChannelException.Create(appInsightsConfig.TelemetryChannel)
+                };
+                TelemetryConfig.TelemetryChannel = _telemetryChannel;
+            }
+        }
     }
 }

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel.csproj
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="DontPanicLabs.Ifx.Telemetry.Logger.Contracts" Version="1.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.7.0" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.7.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights\DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights.csproj" />
+      <ProjectReference Include="..\DontPanicLabs.Ifx.Tests.Shared\DontPanicLabs.Ifx.Tests.Shared.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Remove="appsettings.json" />
+      <Content Include="appsettings.json">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
+
+</Project>

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel/Test.cs
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel/Test.cs
@@ -1,0 +1,18 @@
+using DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights.Exceptions;
+using DontPanicLabs.Ifx.Tests.Shared.Attributes;
+
+namespace DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel;
+
+[TestClass]
+[TestCategoryCI]
+public class Test
+{
+    [TestMethod]
+    public void CreateLogger_AppInsightsTelemetryChannelInvalid_ThrowsInvalidTelemetryChannelException()
+    {
+        var exception = Assert.ThrowsException<InvalidTelemetryChannelException>(() =>
+        {
+            var logger = new Azure.ApplicationInsights.Logger();
+        });
+    }
+}

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel/appsettings.json
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "skipEnvironmentVariables": true,
+  "appSettings": {
+    "noException": true
+  },
+  "ifx": {
+    "telemetry": {
+      "logging": {
+        "applicationInsights": {
+          "ConnectionString": "InstrumentationKey=;IngestionEndpoint=https://localhost;LiveEndpoint=https://localhost;ApplicationId=",
+          "TelemetryChannel": "BadTelemetryChannel"
+        }
+      }
+    }
+  }
+}

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel.csproj
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="DontPanicLabs.Ifx.Telemetry.Logger.Contracts" Version="1.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.7.0" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.7.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Remove="appsettings.json" />
+        <Content Include="appsettings.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights\DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights.csproj" />
+      <ProjectReference Include="..\DontPanicLabs.Ifx.Tests.Shared\DontPanicLabs.Ifx.Tests.Shared.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel/Test.cs
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel/Test.cs
@@ -1,0 +1,42 @@
+using DontPanicLabs.Ifx.Telemetry.Logger.Contracts;
+using DontPanicLabs.Ifx.Tests.Shared.Attributes;
+
+namespace DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel;
+
+/// <summary>
+/// To run this test locally, provide an app insights `ConnectionString` in this project's appsettings.json.
+/// </summary>
+[TestClass]
+[TestCategoryLocal]
+public class Test
+{
+    private Dictionary<string, string>? _customProperties;
+
+    private ILogger? _logger;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        _customProperties = new Dictionary<string, string>
+        {
+            {"RunId", Guid.NewGuid().ToString() }
+        };
+
+        _logger = new Azure.ApplicationInsights.Logger();
+    }
+
+    [TestCleanup]
+    public async Task Cleanup()
+    {
+        _logger!.Flush();
+
+        // `Flush` is not synchronous when using `ServerTelemetryChannel`, wait a bit to allow flush to complete.
+        await Task.Delay(10000);
+    }
+
+    [TestMethod]
+    public void LogWithServerTelemetryChannel()
+    {
+        _logger!.Log("Unit Test Log Message using ServerTelemetryChannel", SeverityLevel.Information, _customProperties!);
+    }
+}

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel/appsettings.json
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "skipEnvironmentVariables": true,
+  "appSettings": {
+    "noException": true
+  },
+  "ifx": {
+    "telemetry": {
+      "logging": {
+        "applicationInsights": {
+          "ConnectionString": "",
+          "TelemetryChannel": "ServerTelemetryChannel"
+        }
+      }
+    }
+  }
+}

--- a/DontPanicLabs.Ifx.sln
+++ b/DontPanicLabs.Ifx.sln
@@ -81,6 +81,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DontPanicLabs.Ifx.Telemetry
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.Success", "DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.Success\DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.Success.csproj", "{36667938-0ACC-4BFC-8E21-03C27D8DA2E3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel", "DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel\DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel.csproj", "{35F7985E-A00F-450E-9785-DEFD53091F0E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel", "DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel\DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel.csproj", "{CFB74269-B14F-459A-AFA2-A396CE7007C4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -183,6 +187,14 @@ Global
 		{36667938-0ACC-4BFC-8E21-03C27D8DA2E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{36667938-0ACC-4BFC-8E21-03C27D8DA2E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{36667938-0ACC-4BFC-8E21-03C27D8DA2E3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35F7985E-A00F-450E-9785-DEFD53091F0E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35F7985E-A00F-450E-9785-DEFD53091F0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35F7985E-A00F-450E-9785-DEFD53091F0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{35F7985E-A00F-450E-9785-DEFD53091F0E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CFB74269-B14F-459A-AFA2-A396CE7007C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CFB74269-B14F-459A-AFA2-A396CE7007C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CFB74269-B14F-459A-AFA2-A396CE7007C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CFB74269-B14F-459A-AFA2-A396CE7007C4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{4A08EA0E-D068-4EDA-8FF7-B8C013EF71CA} = {E8260938-6BFC-4535-829A-B11BF03EA7C1}
@@ -214,5 +226,7 @@ Global
 		{3B963951-C786-416A-9D4A-ADCF8EF940BF} = {21BC52CA-6CE3-42EB-A36A-545B529D3765}
 		{C572848D-D81B-4EE8-9077-6E1FBC5C7478} = {3B963951-C786-416A-9D4A-ADCF8EF940BF}
 		{36667938-0ACC-4BFC-8E21-03C27D8DA2E3} = {3B963951-C786-416A-9D4A-ADCF8EF940BF}
+		{35F7985E-A00F-450E-9785-DEFD53091F0E} = {3B963951-C786-416A-9D4A-ADCF8EF940BF}
+		{CFB74269-B14F-459A-AFA2-A396CE7007C4} = {3B963951-C786-416A-9D4A-ADCF8EF940BF}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
### Description
Through a project that consumes `Dpl.Ifx`, we discovered a memory leak that was ultimately tracked down to be caused by repeated instantiations of `TelemetryConfiguration` in Dpl.Ifx `Logger`.  See #47 for a detailed description of the bug + a demo of the memory leak.

This PR makes `TelemetryConfiguration` static to avoid repeated instantiations of that object which will lead to a memory leak. I implemented in this way based on guidance in https://github.com/microsoft/ApplicationInsights-dotnet/issues/1152#issue-453759517,  "... or create your own global static variable to store TelemetryConfiguration instance you create".

### Remarks
I initially attempted (a56d342) to just move all of the code for instantiating the `TelemetryConfig` object over to a static constructor, but learned that if you throw an exception from within (`EmptyConnectionStringException.ThrowIfEmpty`), that's not the exception that's actually raised - instead, calling code gets a `TypeInitializationException`, and once type init has failed for a type, it's never retried for the lifetime of the application.  Hence the move to do in-line initialization of the `TelemetryConfiguration` obj in the declaration, and an `if` statement (which I don't love) within the `Logger` constructor.