### PR TITLE
Make `AppInsights` telemetry channel configurable via `ifx:telemetry:logging:applicationInsights` config

### DIFF
--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Configuration/AppInsightsConfiguration.cs
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Configuration/AppInsightsConfiguration.cs
@@ -3,5 +3,7 @@
     internal class AppInsightsConfiguration : IAppInsightsConfiguration
     {
         public string? ConnectionString { get; set; }
+
+        public string? TelemetryChannel { get; set; }
     }
 }

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Configuration/IAppInsightsConfiguration.cs
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Configuration/IAppInsightsConfiguration.cs
@@ -3,5 +3,13 @@
     public interface IAppInsightsConfiguration
     {
         string? ConnectionString { get; }
+
+        /// <summary>
+        /// The `TelemetryChannel` to use, either "InMemoryChannel" or "ServerTelemetryChannel".
+        /// </summary>
+        /// <remarks>
+        /// Microsoft recommends using "ServerTelemetryChannel" in all production scenarios.
+        /// </remarks>
+        string? TelemetryChannel { get; }
     }
 }

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights.csproj
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights.csproj
@@ -34,6 +34,7 @@
     <ItemGroup>
       <PackageReference Include="DontPanicLabs.Ifx.Configuration.Local" Version="1.0.0" />
       <PackageReference Include="DontPanicLabs.Ifx.Telemetry.Logger.Contracts" Version="1.0.0" />
+      <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.23.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" />
     </ItemGroup>
 

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Exceptions/InvalidTelemetryChannelException.cs
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Exceptions/InvalidTelemetryChannelException.cs
@@ -8,7 +8,6 @@ public class InvalidTelemetryChannelException : ArgumentException
     {
     }
 
-
     public static InvalidTelemetryChannelException Create(string? channel)
     {
         return new InvalidTelemetryChannelException(string.Format(InvalidTelemetryChannel, channel));

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Exceptions/InvalidTelemetryChannelException.cs
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Exceptions/InvalidTelemetryChannelException.cs
@@ -1,0 +1,24 @@
+namespace DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights.Exceptions;
+
+public class InvalidTelemetryChannelException : ArgumentException
+{
+    private const string InvalidTelemetryChannel = "A `TelemetryChannel` was provided, but its value '{0}' was invalid.";
+
+    InvalidTelemetryChannelException(string message) : base(message)
+    {
+    }
+
+
+    public static InvalidTelemetryChannelException Create(string? channel)
+    {
+        return new InvalidTelemetryChannelException(string.Format(InvalidTelemetryChannel, channel));
+    }
+
+    public static void ThrowIfChannelInvalid(string? channel)
+    {
+        if (!string.IsNullOrEmpty(channel) && channel != "InMemoryChannel" && channel != "ServerTelemetryChannel")
+        {
+            throw Create(channel);
+        }
+    }
+}

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Logger.cs
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Logger.cs
@@ -4,7 +4,6 @@ using DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights.Exceptions;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.Extensions.Configuration;
 
 namespace DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights
 {

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Logger.cs
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights/Logger.cs
@@ -2,6 +2,7 @@ using DontPanicLabs.Ifx.Configuration.Local;
 using DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights.Configuration;
 using DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights.Exceptions;
 using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.Extensions.Configuration;
 
@@ -10,6 +11,8 @@ namespace DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights
     public sealed class Logger : Contracts.ILogger
     {
         private readonly TelemetryClient _TelemetryClient;
+
+        private static ITelemetryChannel? _telemetryChannel;
 
         /// <remarks>
         /// `TelemetryConfiguration` is static so that it can be reused across instances of the logger; failure to
@@ -20,15 +23,9 @@ namespace DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights
 
         public Logger()
         {
-            IConfiguration configuration = new Config();
-            IAppInsightsConfiguration appInsightsConfig = configuration.GetAppInsightsConfiguration();
+            IAppInsightsConfiguration appInsightsConfig = new Config().GetAppInsightsConfiguration();
 
-            EmptyConnectionStringException.ThrowIfEmpty(appInsightsConfig.ConnectionString!);
-
-            if (string.IsNullOrEmpty(TelemetryConfig.ConnectionString))
-            {
-                TelemetryConfig.ConnectionString = appInsightsConfig.ConnectionString;
-            }
+            ConfigureTelemetry(appInsightsConfig);
 
             _TelemetryClient = new TelemetryClient(TelemetryConfig);
         }
@@ -68,5 +65,24 @@ namespace DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights
             _TelemetryClient.TrackException(ex, properties);
         }
 
+        private static void ConfigureTelemetry(IAppInsightsConfiguration appInsightsConfig)
+        {
+            EmptyConnectionStringException.ThrowIfEmpty(appInsightsConfig.ConnectionString!);
+            TelemetryConfig.ConnectionString ??= appInsightsConfig.ConnectionString;
+
+            InvalidTelemetryChannelException.ThrowIfChannelInvalid(appInsightsConfig.TelemetryChannel);
+            if (_telemetryChannel == null)
+            {
+                _telemetryChannel = appInsightsConfig.TelemetryChannel switch
+                {
+                    "ServerTelemetryChannel" =>
+                        new Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel(),
+                    var channel when string.IsNullOrEmpty(channel) || channel == "InMemoryChannel" =>
+                        new InMemoryChannel(),
+                    _ => throw InvalidTelemetryChannelException.Create(appInsightsConfig.TelemetryChannel)
+                };
+                TelemetryConfig.TelemetryChannel = _telemetryChannel;
+            }
+        }
     }
 }

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel.csproj
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="DontPanicLabs.Ifx.Telemetry.Logger.Contracts" Version="1.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.7.0" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.7.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights\DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights.csproj" />
+      <ProjectReference Include="..\DontPanicLabs.Ifx.Tests.Shared\DontPanicLabs.Ifx.Tests.Shared.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Remove="appsettings.json" />
+      <Content Include="appsettings.json">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
+
+</Project>

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel/Test.cs
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel/Test.cs
@@ -1,0 +1,18 @@
+using DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights.Exceptions;
+using DontPanicLabs.Ifx.Tests.Shared.Attributes;
+
+namespace DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel;
+
+[TestClass]
+[TestCategoryCI]
+public class Test
+{
+    [TestMethod]
+    public void CreateLogger_AppInsightsTelemetryChannelInvalid_ThrowsInvalidTelemetryChannelException()
+    {
+        var exception = Assert.ThrowsException<InvalidTelemetryChannelException>(() =>
+        {
+            var logger = new Azure.ApplicationInsights.Logger();
+        });
+    }
+}

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel/appsettings.json
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "skipEnvironmentVariables": true,
+  "appSettings": {
+    "noException": true
+  },
+  "ifx": {
+    "telemetry": {
+      "logging": {
+        "applicationInsights": {
+          "ConnectionString": "InstrumentationKey=;IngestionEndpoint=https://localhost;LiveEndpoint=https://localhost;ApplicationId=",
+          "TelemetryChannel": "BadTelemetryChannel"
+        }
+      }
+    }
+  }
+}

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel.csproj
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="DontPanicLabs.Ifx.Telemetry.Logger.Contracts" Version="1.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.7.0" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.7.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Remove="appsettings.json" />
+        <Content Include="appsettings.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights\DontPanicLabs.Ifx.Telemetry.Logger.Azure.ApplicationInsights.csproj" />
+      <ProjectReference Include="..\DontPanicLabs.Ifx.Tests.Shared\DontPanicLabs.Ifx.Tests.Shared.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel/Test.cs
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel/Test.cs
@@ -1,0 +1,42 @@
+using DontPanicLabs.Ifx.Telemetry.Logger.Contracts;
+using DontPanicLabs.Ifx.Tests.Shared.Attributes;
+
+namespace DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel;
+
+/// <summary>
+/// To run this test locally, provide an app insights `ConnectionString` in this project's appsettings.json.
+/// </summary>
+[TestClass]
+[TestCategoryLocal]
+public class Test
+{
+    private Dictionary<string, string>? _customProperties;
+
+    private ILogger? _logger;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        _customProperties = new Dictionary<string, string>
+        {
+            {"RunId", Guid.NewGuid().ToString() }
+        };
+
+        _logger = new Azure.ApplicationInsights.Logger();
+    }
+
+    [TestCleanup]
+    public async Task Cleanup()
+    {
+        _logger!.Flush();
+
+        // `Flush` is not synchronous when using `ServerTelemetryChannel`, wait a bit to allow flush to complete.
+        await Task.Delay(10000);
+    }
+
+    [TestMethod]
+    public void LogWithServerTelemetryChannel()
+    {
+        _logger!.Log("Unit Test Log Message using ServerTelemetryChannel", SeverityLevel.Information, _customProperties!);
+    }
+}

--- a/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel/appsettings.json
+++ b/DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "skipEnvironmentVariables": true,
+  "appSettings": {
+    "noException": true
+  },
+  "ifx": {
+    "telemetry": {
+      "logging": {
+        "applicationInsights": {
+          "ConnectionString": "",
+          "TelemetryChannel": "ServerTelemetryChannel"
+        }
+      }
+    }
+  }
+}

--- a/DontPanicLabs.Ifx.sln
+++ b/DontPanicLabs.Ifx.sln
@@ -81,6 +81,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DontPanicLabs.Ifx.Telemetry
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.Success", "DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.Success\DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.Success.csproj", "{36667938-0ACC-4BFC-8E21-03C27D8DA2E3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel", "DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel\DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel.csproj", "{35F7985E-A00F-450E-9785-DEFD53091F0E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -183,6 +185,10 @@ Global
 		{36667938-0ACC-4BFC-8E21-03C27D8DA2E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{36667938-0ACC-4BFC-8E21-03C27D8DA2E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{36667938-0ACC-4BFC-8E21-03C27D8DA2E3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35F7985E-A00F-450E-9785-DEFD53091F0E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35F7985E-A00F-450E-9785-DEFD53091F0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35F7985E-A00F-450E-9785-DEFD53091F0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{35F7985E-A00F-450E-9785-DEFD53091F0E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{4A08EA0E-D068-4EDA-8FF7-B8C013EF71CA} = {E8260938-6BFC-4535-829A-B11BF03EA7C1}
@@ -214,5 +220,6 @@ Global
 		{3B963951-C786-416A-9D4A-ADCF8EF940BF} = {21BC52CA-6CE3-42EB-A36A-545B529D3765}
 		{C572848D-D81B-4EE8-9077-6E1FBC5C7478} = {3B963951-C786-416A-9D4A-ADCF8EF940BF}
 		{36667938-0ACC-4BFC-8E21-03C27D8DA2E3} = {3B963951-C786-416A-9D4A-ADCF8EF940BF}
+		{35F7985E-A00F-450E-9785-DEFD53091F0E} = {3B963951-C786-416A-9D4A-ADCF8EF940BF}
 	EndGlobalSection
 EndGlobal

--- a/DontPanicLabs.Ifx.sln
+++ b/DontPanicLabs.Ifx.sln
@@ -83,6 +83,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DontPanicLabs.Ifx.Telemetry
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel", "DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel\DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.InvalidTelemetryChannel.csproj", "{35F7985E-A00F-450E-9785-DEFD53091F0E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel", "DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel\DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel.csproj", "{CFB74269-B14F-459A-AFA2-A396CE7007C4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -189,6 +191,10 @@ Global
 		{35F7985E-A00F-450E-9785-DEFD53091F0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{35F7985E-A00F-450E-9785-DEFD53091F0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{35F7985E-A00F-450E-9785-DEFD53091F0E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CFB74269-B14F-459A-AFA2-A396CE7007C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CFB74269-B14F-459A-AFA2-A396CE7007C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CFB74269-B14F-459A-AFA2-A396CE7007C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CFB74269-B14F-459A-AFA2-A396CE7007C4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{4A08EA0E-D068-4EDA-8FF7-B8C013EF71CA} = {E8260938-6BFC-4535-829A-B11BF03EA7C1}
@@ -221,5 +227,6 @@ Global
 		{C572848D-D81B-4EE8-9077-6E1FBC5C7478} = {3B963951-C786-416A-9D4A-ADCF8EF940BF}
 		{36667938-0ACC-4BFC-8E21-03C27D8DA2E3} = {3B963951-C786-416A-9D4A-ADCF8EF940BF}
 		{35F7985E-A00F-450E-9785-DEFD53091F0E} = {3B963951-C786-416A-9D4A-ADCF8EF940BF}
+		{CFB74269-B14F-459A-AFA2-A396CE7007C4} = {3B963951-C786-416A-9D4A-ADCF8EF940BF}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This PR allows us to configure the telemetry channel used by our app insights logger (can use either `InMemoryChannel` or `ServerTelemetryChannel`) via an optional. The default is `InMemoryChannel`.  Through #48, I found that Microsoft recommends using `ServerTelemetryChannel` in all production scenarios. Per docs:

- `InMemoryChannel`: "This channel offers minimal reliability guarantees because it doesn't retry sending telemetry after a failure. This channel also doesn't keep items on disk. So any unsent items are lost permanently upon application shutdown, whether it's graceful or not. This channel is well suited for short-running applications where a synchronous flush is ideal."
- `ServerTelemetryChannel`: "A more advanced channel that has retry policies and the capability to store data on a local disk ... This channel is optimized for server scenarios with long-running processes ... **We recommend it for all production scenarios."**

### Testing
I ran the test suite locally, providing a valid `ConnectionString` for:
- The pre-existing `DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.Success` test, which is missing the new `TelemetryChannel` config key to ensure this PR doesn't break pre-existing code (defaults to previous behavior of using `InMemoryChannel`)
- The new `DontPanicLabs.Ifx.Telemetry.Logger.Azure.Tests.ApplicationInsights.ServerTelemetryChannel` test added in this PR, to show the `ServerTelemetryChannel` working.

Running these tests, both pass, and both modes get logs into app insights:
![image](https://github.com/user-attachments/assets/eded266c-9015-4ab8-aaeb-78446a21dcd0)

Since the `TelemetryChannel` is `private`, in lieu of a unit test, I verified that when debugging the `ServerTelemetryChannel` test, the `_logger` instance ends up with the `ServerTelemetryChannel` in its configuration:

![image](https://github.com/user-attachments/assets/8de869a8-812b-4bab-a7ac-81125ef922a4)

