### PR TITLE
Fix DtoMapper integration tests to use Docker SQL Server instead of LocalDB

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,6 +18,20 @@ jobs:
 
     runs-on: ubuntu-22.04
 
+    services:
+      sqlserver:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: DtoMapper!Dev2024
+        ports:
+          - 1433:1433
+        options: >-
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'DtoMapper!Dev2024' -C -Q 'SELECT 1' -b"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
@@ -25,8 +39,12 @@ jobs:
       with:
         dotnet-version: 10.0.x
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore DontPanicLabs.Ifx.sln
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build DontPanicLabs.Ifx.sln --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal --filter TestCategory=CI
+      run: dotnet test DontPanicLabs.Ifx.sln --no-build --verbosity normal --filter TestCategory=CI
+    - name: Test (DtoMapper Integration)
+      run: dotnet test DontPanicLabs.Ifx.Mapping.DtoMapper.IntegrationTests --no-build --verbosity normal
+      env:
+        DTOMAPPER_SQL_CONNECTION: "Server=localhost,1433;User Id=sa;Password=DtoMapper!Dev2024;MultipleActiveResultSets=True;Connection Timeout=300;TrustServerCertificate=True"

--- a/DontPanicLabs.Ifx.Mapping.DtoMapper.IntegrationTests/IntegrationTest.cs
+++ b/DontPanicLabs.Ifx.Mapping.DtoMapper.IntegrationTests/IntegrationTest.cs
@@ -28,6 +28,15 @@ public class DropCreateDatabaseAlways<TContext> : IInitializer where TContext : 
 public abstract class LocalDbContext : DbContext
 {
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) => optionsBuilder.UseSqlServer(
-        @$"Data Source=(localdb)\mssqllocaldb;Integrated Security=True;MultipleActiveResultSets=True;Database={GetType()};Connection Timeout=300",
+        BuildConnectionString(GetType().ToString()),
         o => o.EnableRetryOnFailure(maxRetryCount: 10).CommandTimeout(120));
+
+    private static string BuildConnectionString(string databaseName)
+    {
+        var baseConnection = Environment.GetEnvironmentVariable("DTOMAPPER_SQL_CONNECTION");
+        if (!string.IsNullOrWhiteSpace(baseConnection))
+            return $"{baseConnection};Database={databaseName}";
+
+        return $@"Data Source=(localdb)\mssqllocaldb;Integrated Security=True;MultipleActiveResultSets=True;Database={databaseName};Connection Timeout=300";
+    }
 }

--- a/DontPanicLabs.Ifx.Mapping.DtoMapper.IntegrationTests/docker-compose.yml
+++ b/DontPanicLabs.Ifx.Mapping.DtoMapper.IntegrationTests/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      ACCEPT_EULA: "Y"
+      SA_PASSWORD: "DtoMapper!Dev2024"
+    ports:
+      - "1433:1433"
+    healthcheck:
+      test: /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "DtoMapper!Dev2024" -C -Q "SELECT 1" -b
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s


### PR DESCRIPTION
## Summary

- Replaces hardcoded LocalDB connection string in `LocalDbContext` with env var `DTOMAPPER_SQL_CONNECTION`, falling back to LocalDB for local Windows dev
- Adds `docker-compose.yml` to `DontPanicLabs.Ifx.DtoMapper.IntegrationTests/` for spinning up SQL Server 2022 locally
- Updates CI workflow to spin up a SQL Server service container and run the 128 integration tests as a dedicated step
- Pins all CI `dotnet` commands to `DontPanicLabs.Ifx.sln` to avoid MSB1011 ambiguity from the `.slnx` in the DtoMapper folder